### PR TITLE
fix: Disable best practices in maven-gpg-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -239,7 +239,6 @@
             <artifactId>maven-gpg-plugin</artifactId>
             <configuration>
               <signer>bc</signer>
-              <bestPractices>true</bestPractices>
             </configuration>
             <executions>
               <execution>


### PR DESCRIPTION
It's currently failing with the following error message:
```
Error:  Failed to execute goal org.apache.maven.plugins:maven-gpg-plugin:3.2.2:sign (sign-artifacts) on project module-parent: Do not store passphrase in any file (disk or SCM repository), rely on GnuPG agent or provide passphrase in MAVEN_GPG_PASSPHRASE environment variable. -> [Help 1]
```